### PR TITLE
Hardcode auth config in UI

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -93,10 +93,12 @@ export default function App() {
   React.useEffect(() => {
     const Keycloak = window.Keycloak;
     var keycloakClient;
-    if (window.location.origin.startsWith("http://localhost"))
+    if (window.location.origin.startsWith("http://localhost")) {
       keycloakClient = new Keycloak("./keycloak.json");
-    else
-      keycloakClient = new Keycloak(window.location.origin + "/api/v1/authconfig");
+    } else {
+      var clientConfig = JSON.parse("{\"realm\":\"devcluster-public-prod\",\"auth-server-url\":\"https://sso.prod-preview.openshift.io/auth\",\"ssl-required\":\"none\",\"resource\":\"devcluster-public-prod\",\"clientId\":\"devcluster-public-prod\",\"public-client\":true}");
+      keycloakClient = Keycloak(clientConfig);
+    }
     keycloakClient.init({onLoad: 'check-sso', silentCheckSsoRedirectUri: window.location.origin})
       .success(authenticated => {
         axios.defaults.headers.common['Authorization'] = 'Bearer ' + keycloakClient.idToken;


### PR DESCRIPTION
We can't just pass `/api/v1/authconfig` URL to `Keycloak()`. That endpoint returns our own JSON where the KC config is in "auth-client-config".
I hardcoded the KC config in UI for now but we need to fix it properly.
Both keycloak.js and keycloak config should be loaded from `/api/v1/authconfig` properly.