### PR TITLE
UI should allow to request less than 10 clusters

### DIFF
--- a/ui/src/components/requestform.js
+++ b/ui/src/components/requestform.js
@@ -42,12 +42,12 @@ export default function RequestForm({ zones, onSubmit }) {
         <FormControl className={classes.formControl} style={{minWidth: '220px'}}>
             <InputLabel id='clustern-label'>Number of Clusters</InputLabel>
             <Slider
-                defaultValue={10}
+                defaultValue={1}
                 aria-labelledby='clustern-label'
                 valueLabelDisplay='auto'
-                step={10}
+                step={1}
                 marks
-                min={10}
+                min={1}
                 max={500}
                 onChange={(event, newValue) => setNumberOfClusters(newValue)}
             />

--- a/ui/src/components/requestform.js
+++ b/ui/src/components/requestform.js
@@ -48,7 +48,7 @@ export default function RequestForm({ zones, onSubmit }) {
                 step={1}
                 marks
                 min={1}
-                max={500}
+                max={200}
                 onChange={(event, newValue) => setNumberOfClusters(newValue)}
             />
         </FormControl>


### PR DESCRIPTION
@michaelkleinhenz we need a better UX for the cluster and user requests. Especially for the clusters. 10 minimum with 10 step is too limited. Sometimes (especially for testing) we need to create just a few clusters.

Ideally we need something better for the cluster timeout too. We might want to create very short lived clusters (<24 hours) from time to time too.

For now I'm making the cluster request slider more fine grained to unblock me but I wonder if sliders actually are good choice for us.