### PR TITLE
155 hours by default, 170 hours max for cluster request

### DIFF
--- a/ui/src/components/requestform.js
+++ b/ui/src/components/requestform.js
@@ -49,8 +49,11 @@ export default function RequestForm({ zones, onSubmit }) {
         <FormControl className={classes.formControl} style={{minWidth: '220px'}}>
             <TextField
                 label="Delete in Hours"
-                defaultValue={24}
+                defaultValue={155}
                 type="number"
+                InputProps={{
+                  inputProps: { min: 1, max: 170 },
+                }}
                 InputLabelProps={{
                   shrink: true,
                 }}


### PR DESCRIPTION
155 is the default value for the cluster lifespan.

I'm also trying to set the acceptable range for that to 1..170 but it seems that I still can type any number to the field. The arrows use the range though.

@michaelkleinhenz please take a look and maybe you know how to set the range properly.