### PR TITLE
Create clusters one by one

### DIFF
--- a/pkg/auth/id_test.go
+++ b/pkg/auth/id_test.go
@@ -25,11 +25,11 @@ func (s *TestIDSuite) TestKeyManagerDefaultKeyManager() {
 	s.Run("generate ID with prefix", func() {
 		id := auth.GenerateShortID("rhd")
 		assert.True(s.T(), strings.HasPrefix(id, "rhd-"))
-		assert.True(s.T(), len(id) > 10)
+		assert.True(s.T(), len(id) > 7, "expected format: %s, actual ID: %s", "rhd-xxx", id)
 	})
 	s.Run("generate ID no prefix", func() {
 		id := auth.GenerateShortID("")
-		assert.False(s.T(), strings.HasPrefix(id, "-"))
+		assert.False(s.T(), strings.HasPrefix(id, "-"), "expected format: %s, actual ID: %s", "xxx", id)
 	})
 	s.Run("generate ID with date", func() {
 		prefix := fmt.Sprintf("rhd-%s-", time.Now().Format("Jan02"))

--- a/pkg/cluster/mongo.go
+++ b/pkg/cluster/mongo.go
@@ -124,6 +124,7 @@ func replaceCluster(c Cluster) error {
 	return errors.Wrap(err, "unable to replace cluster")
 }
 
+// getCluster finds the cluster by its id. Returns nil, nil if there is no cluster with that id.
 func getCluster(id string) (*Cluster, error) {
 	res := mongodb.Clusters().FindOne(
 		context.Background(),
@@ -131,6 +132,27 @@ func getCluster(id string) (*Cluster, error) {
 	)
 	if res == nil {
 		return nil, errors.New(fmt.Sprintf("unable to find Cluster with such ID: %s", id))
+	}
+	var m bson.M
+	err := res.Decode(&m)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "unable to get cluster from mongo")
+	}
+	c := convertBSONToCluster(m)
+	return &c, nil
+}
+
+// getClusterByName finds the cluster by its name. Returns nil, nil if there is no cluster with that name.
+func getClusterByName(name string) (*Cluster, error) {
+	res := mongodb.Clusters().FindOne(
+		context.Background(),
+		bson.D{{"name", name}},
+	)
+	if res == nil {
+		return nil, errors.New(fmt.Sprintf("unable to find Cluster with such name: %s", name))
 	}
 	var m bson.M
 	err := res.Decode(&m)


### PR DESCRIPTION
Creating too many clusters concurrently may cause 50x errors on the IBM Cloud side. This PR changes the logic of cluster creation. Now we create the next cluster in the request only if the previous one succeed or failed. Then we poll the cluster status in a separate go routine as before.